### PR TITLE
Add image column and populate package images

### DIFF
--- a/frontend/database.sql
+++ b/frontend/database.sql
@@ -66,3 +66,13 @@ INSERT INTO packages (destination_id, title, description, duration_days, price) 
 (4, 'Paris Experience', 'France package with city tours.', 4, 900.00),
 (5, 'Japan Discovery', 'Tokyo and Kyoto travel package.', 8, 1500.00),
 (6, 'Australia Escape', 'Sydney and coastal travel package.', 10, 1800.00);
+
+ALTER TABLE packages
+ADD image VARCHAR(255) NULL AFTER price;
+
+UPDATE packages SET image = 'images/img-4.jpg' WHERE id = 1;
+UPDATE packages SET image = 'images/img-8.jpg' WHERE id = 2;
+UPDATE packages SET image = 'images/img-9.jpg' WHERE id = 3;
+UPDATE packages SET image = 'images/img-11.jpg' WHERE id = 4;
+UPDATE packages SET image = 'images/img-12.jpg' WHERE id = 5;
+UPDATE packages SET image = 'images/img-6.jpg' WHERE id = 6;


### PR DESCRIPTION
Modify frontend/database.sql to add an image column to the packages table (ALTER TABLE ... ADD image VARCHAR(255) NULL AFTER price) and populate image paths for existing package rows with UPDATE statements for ids 1–6. This enables storing/displaying package images in the frontend.