### PR TITLE
Load packages from DB and add DB connection

### DIFF
--- a/frontend/includes/DB.php
+++ b/frontend/includes/DB.php
@@ -1,0 +1,16 @@
+<?php
+$host = 'localhost';
+$dbname = 'agjensioni-turistik';
+$user = 'root';
+$pass = '';
+
+try {
+    $pdo = new PDO(
+        "mysql:host=$host;dbname=$dbname;charset=utf8mb4",
+        $user,
+        $pass,
+        [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+    );
+} catch (PDOException $e) {
+    die("Nuk u lidh me databaze.");
+}

--- a/frontend/package.php
+++ b/frontend/package.php
@@ -6,16 +6,32 @@ if (!isset($_SESSION['user_id'])) {
     exit;
 }
 
-include '../classes/Package.php';
+require_once '../includes/DB.php';
 
-$packages = [
-    new Package("India", "Explore the rich culture of India", "images/img-9.jpg"),
-    new Package("Switzerland", "Beautiful mountains and lakes", "images/img-8.jpg"),
-    new Package("Latvia", "Hidden gem in Europe", "images/img-7.jpg"),
-    new Package("France", "Romantic destinations", "images/img-4.jpg"),
-    new Package("Japan", "Modern and traditional mix", "images/img-5.jpg"),
-    new Package("Australia", "Adventure and nature", "images/img-6.jpg")
-];
+$error = '';
+
+try {
+    $stmt = $pdo->prepare("
+        SELECT 
+            packages.id,
+            packages.destination_id,
+            packages.title,
+            packages.description,
+            packages.duration_days,
+            packages.price,
+            packages.image,
+            destinations.name AS destination_name,
+            destinations.country
+        FROM packages
+        INNER JOIN destinations ON packages.destination_id = destinations.id
+        ORDER BY packages.id DESC
+    ");
+    $stmt->execute();
+    $packages = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} catch (PDOException $e) {
+    $packages = [];
+    $error = "Nuk mund te ngarkohen paketat.";
+}
 ?>
 
 <!DOCTYPE html>


### PR DESCRIPTION
Add a new PDO-based DB connection (frontend/includes/DB.php) and replace the hardcoded packages array in frontend/package.php with a database query. package.php now requires the DB file, selects package fields joined with destinations (ordered by id desc), fetches results as associative arrays, and sets an $error message on failure. Removes the previous Package class usage and introduces basic error handling.