### PR TITLE
Add package deletion API endpoint

### DIFF
--- a/frontend/api/delete-package.php
+++ b/frontend/api/delete-package.php
@@ -1,0 +1,26 @@
+<?php
+session_start();
+require_once '../includes/DB.php';
+
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['role']) || $_SESSION['role'] !== 'admin') {
+    echo json_encode(['success' => false, 'message' => 'Nuk ke autorizim.']);
+    exit;
+}
+
+$id = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT);
+
+if (!$id) {
+    echo json_encode(['success' => false, 'message' => 'ID nuk eshte valide.']);
+    exit;
+}
+
+try {
+    $stmt = $pdo->prepare("DELETE FROM packages WHERE id = ?");
+    $stmt->execute([$id]);
+
+    echo json_encode(['success' => true]);
+} catch (PDOException $e) {
+    echo json_encode(['success' => false, 'message' => 'Gabim ne databaze.']);
+}


### PR DESCRIPTION
Create frontend/api/delete-package.php: a POST API that deletes a package by id. It requires an active session with role 'admin', validates the id as an integer, uses a prepared PDO DELETE query, and returns JSON success or error messages (Albanian). Catches PDO exceptions and returns a generic database error message.