### PR TITLE
Remove packages.image column and duplicate entry

### DIFF
--- a/frontend/database.sql
+++ b/frontend/database.sql
@@ -33,7 +33,6 @@ CREATE TABLE packages (
     description TEXT,
     duration_days INT NOT NULL,
     price DECIMAL(10,2) NOT NULL,
-    image VARCHAR(255) NULL,
     FOREIGN KEY (destination_id) REFERENCES destinations(id)
 ) ENGINE=InnoDB;
 
@@ -60,11 +59,11 @@ INSERT INTO destinations (name, country, price) VALUES
 ('Japan', 'Japan', 1500.00),
 ('Australia', 'Australia', 1800.00);
 
-INSERT INTO packages (destination_id, title, description, duration_days, price, image) VALUES
-(1, 'India Adventure', 'Cultural trip with guided tours.', 7, 650.00, 'images/img-4.jpg'),
-(2, 'Swiss Alps Tour', 'Mountain and lake experience.', 5, 1200.00, 'images/img-8.jpg'),
-(3, 'Latvia City Break', 'Short city trip package.', 3, 500.00, 'images/img-9.jpg'),
-(4, 'Paris Experience', 'France package with city tours.', 4, 900.00, 'images/img-11.jpg'),
-(5, 'Japan Discovery', 'Tokyo and Kyoto travel package.', 8, 1500.00, 'images/img-12.jpg'),
-(6, 'Australia Escape', 'Sydney and coastal travel package.', 10, 1800.00, 'images/img-6.jpg');
+INSERT INTO packages (destination_id, title, description, duration_days, price) VALUES
+(1, 'India Adventure', 'Cultural trip with guided tours.', 7, 650.00),
+(2, 'Swiss Alps Tour', 'Mountain and lake experience.', 5, 1200.00),
+(3, 'Latvia City Break', 'Short city trip package.', 3, 500.00),
+(4, 'Paris Experience', 'France package with city tours.', 4, 900.00),
+(5, 'Japan Discovery', 'Tokyo and Kyoto travel package.', 8, 1500.00),
+(6, 'Australia Escape', 'Sydney and coastal travel package.', 10, 1800.00);
 

--- a/frontend/package.php
+++ b/frontend/package.php
@@ -17,8 +17,7 @@ $packages = [
     new Package("Latvia", "Hidden gem in Europe", "../images/img-3.jpg"),
     new Package("France", "Romantic destinations", "../images/img-4.jpg"),
     new Package("Japan", "Modern and traditional mix", "../images/img-5.jpg"),
-    new Package("Australia", "Adventure and nature", "../images/img-6.jpg"),
-    new Package("Kosova", "Adventure and nature", "../images/img-6.jpg")
+    new Package("Australia", "Adventure and nature", "../images/img-6.jpg")
 ];
 ?>
 


### PR DESCRIPTION
Drop the image column from the packages table and update the INSERT statements to omit image values so they match the new schema. Also remove a duplicate package entry ('Kosova') from frontend/package.php (leaving only the Australia entry). If deploying to a live DB, migrate or back up any image data before applying this change.