### PR TITLE
Add admin booking deletion (backend + UI)

### DIFF
--- a/frontend/delete-booking.php
+++ b/frontend/delete-booking.php
@@ -1,0 +1,27 @@
+<?php
+session_start();
+require_once "db.php";
+
+header("Content-Type: application/json");
+
+if (!isset($_SESSION["role"]) || $_SESSION["role"] !== "admin") {
+    echo json_encode(["success" => false, "message" => "Only admin can delete bookings."]);
+    exit;
+}
+
+$id = filter_input(INPUT_POST, "id", FILTER_VALIDATE_INT);
+
+if (!$id) {
+    echo json_encode(["success" => false, "message" => "Invalid booking ID."]);
+    exit;
+}
+
+try {
+    $stmt = $pdo->prepare("DELETE FROM bookings WHERE id = ?");
+    $stmt->execute([$id]);
+
+    echo json_encode(["success" => true]);
+} catch (PDOException $e) {
+    echo json_encode(["success" => false, "message" => "Database error."]);
+}
+?>

--- a/frontend/my_bookings.php
+++ b/frontend/my_bookings.php
@@ -47,25 +47,57 @@ function clean($value) {
                 <th>Arrivals</th>
                 <th>Leaving</th>
                 <th>Status</th>
+                <th>Action</th>
             </tr>
 
-            <?php foreach ($bookings as $booking): ?>
-            <tr>
-                <td><?php echo clean($booking["name"]); ?></td>
-                <td><?php echo clean($booking["email"]); ?></td>
-                <td><?php echo clean($booking["phone"]); ?></td>
-                <td><?php echo clean($booking["destination_name"]); ?></td>
-                <td><?php echo clean($booking["guests"]); ?></td>
-                <td><?php echo clean($booking["arrivals"]); ?></td>
-                <td><?php echo clean($booking["leaving"]); ?></td>
-                <td><?php echo clean($booking["status"]); ?></td>
-            </tr>
-            <?php endforeach; ?>
+<?php foreach ($bookings as $booking): ?>
+<tr id="booking-<?php echo (int)$booking["id"]; ?>">
+    <td><?php echo clean($booking["name"]); ?></td>
+    <td><?php echo clean($booking["email"]); ?></td>
+    <td><?php echo clean($booking["phone"]); ?></td>
+    <td><?php echo clean($booking["destination_name"]); ?></td>
+    <td><?php echo clean($booking["guests"]); ?></td>
+    <td><?php echo clean($booking["arrivals"]); ?></td>
+    <td><?php echo clean($booking["leaving"]); ?></td>
+    <td><?php echo clean($booking["status"]); ?></td>
+    <td>
+        <button class="delete-booking-btn" data-id="<?php echo (int)$booking["id"]; ?>">
+            Delete
+        </button>
+    </td>
+</tr>
+<?php endforeach; ?>
         </table>
     </section>
 
     <?php include "footer.php"; ?>
+<script>
+document.querySelectorAll(".delete-booking-btn").forEach(button => {
+    button.addEventListener("click", async function () {
+        if (!confirm("A je i sigurt qe deshiron me fshi kete booking?")) {
+            return;
+        }
 
+        const bookingId = this.dataset.id;
+
+        const formData = new FormData();
+        formData.append("id", bookingId);
+
+        const response = await fetch("delete-booking.php", {
+            method: "POST",
+            body: formData
+        });
+
+        const result = await response.json();
+
+        if (result.success) {
+            document.getElementById("booking-" + bookingId).remove();
+        } else {
+            alert(result.message || "Gabim gjate fshirjes.");
+        }
+    });
+});
+</script>
 </body>
 
 </html>


### PR DESCRIPTION
Add server endpoint and UI for admin to delete bookings. Creates frontend/delete-booking.php which validates admin session, checks integer booking ID, and deletes the row via a prepared PDO statement, returning JSON success/error. Update frontend/my_bookings.php to add an Action column, per-row delete buttons (with row id attributes), and client-side JS that confirms the action, posts the booking ID to delete-booking.php, and removes the row on success. Basic input validation and error handling included.