### PR TITLE
Remove admin Edit link in package.php

### DIFF
--- a/frontend/package.php
+++ b/frontend/package.php
@@ -71,10 +71,9 @@ $packages = [
 
                     <p class="weather-result"></p>
 
-                    <?php if (isset($_SESSION['role']) && $_SESSION['role'] == "admin") { ?>
-                        <a href="#" class="btn">Edit</a>
-                        <button type="button" class="btn delete-package-btn">Delete</button>
-                    <?php } ?>
+<?php if (isset($_SESSION['role']) && $_SESSION['role'] == "admin") { ?>
+    <button type="button" class="btn delete-package-btn">Delete</button>
+<?php } ?>
 
                     <a href="book.html" class="btn">book now</a>
                 </div>


### PR DESCRIPTION
Remove the admin 'Edit' anchor from frontend/package.php, leaving only the Delete button for users with the admin role. Also normalize the PHP conditional tag formatting around the admin block.