### PR TITLE
Use shared header.php in package.php

### DIFF
--- a/frontend/package.php
+++ b/frontend/package.php
@@ -33,16 +33,7 @@ $packages = [
 </head>
 <body>
 
-<section class="header">
-    <a href="index.php" class="logo">travel.</a>
-
-    <nav class="navbar">
-        <a href="index.php">Home</a>
-        <a href="package.php">Package</a>
-        <a href="book.html">Book</a>
-        <a href="about.html">About</a>
-    </nav>
-</section>
+<?php include 'header.php'; ?>
 
 <div class="heading" style="background:url(images/header-bg-2.png) no-repeat">
     <h1>packages</h1>


### PR DESCRIPTION
Replace hardcoded header markup in frontend/package.php with an include of header.php to centralize the header/navigation markup, reducing duplication and simplifying future maintenance.